### PR TITLE
fix handler, add samesite cookie parameter

### DIFF
--- a/handlers.user.go
+++ b/handlers.user.go
@@ -22,11 +22,13 @@ func performLogin(c *gin.Context) {
 	username := c.PostForm("username")
 	password := c.PostForm("password")
 
+    var sameSiteCookie http.SameSite;
+
 	// Check if the username/password combination is valid
 	if isUserValid(username, password) {
 		// If the username/password is valid set the token in a cookie
 		token := generateSessionToken()
-		c.SetCookie("token", token, 3600, "", "", false, true)
+		c.SetCookie("token", token, 3600, "", "", sameSiteCookie, false, true)
 		c.Set("is_logged_in", true)
 
 		render(c, gin.H{
@@ -49,8 +51,11 @@ func generateSessionToken() string {
 }
 
 func logout(c *gin.Context) {
+
+    var sameSiteCookie http.SameSite;
+
 	// Clear the cookie
-	c.SetCookie("token", "", -1, "", "", false, true)
+	c.SetCookie("token", "", -1, "", "", sameSiteCookie, false, true)
 
 	// Redirect to the home page
 	c.Redirect(http.StatusTemporaryRedirect, "/")
@@ -67,10 +72,12 @@ func register(c *gin.Context) {
 	username := c.PostForm("username")
 	password := c.PostForm("password")
 
+    var sameSiteCookie http.SameSite;
+
 	if _, err := registerNewUser(username, password); err == nil {
 		// If the user is created, set the token in a cookie and log the user in
 		token := generateSessionToken()
-		c.SetCookie("token", token, 3600, "", "", false, true)
+		c.SetCookie("token", token, 3600, "", "", sameSiteCookie, false, true)
 		c.Set("is_logged_in", true)
 
 		render(c, gin.H{


### PR DESCRIPTION
I'm updating the tutorial post on Semaphore blog. 

I found that this project no longer builds, as Gin Context setCookie now requires an additional parameter:

https://github.com/gin-gonic/gin/pull/1615

I added the missing parameter with its default value and it seems it's working.

